### PR TITLE
Add a getNativeTokenManagementFrom precompile

### DIFF
--- a/ArbOwnerPublic.sol
+++ b/ArbOwnerPublic.sol
@@ -24,6 +24,11 @@ interface ArbOwnerPublic {
     /// @notice Retrieves the list of chain owners
     function getAllChainOwners() external view returns (address[] memory);
 
+		/// @notice Retrieves the timestamp from when the native token maagement
+		/// modifications are enabled.
+		/// Available in ArbOS version 42
+		function getNativeTokenManagementFrom() external view returns (uint64);
+
     /// @notice See if the user is a native token owner
     /// Available in ArbOS version 41
     function isNativeTokenOwner(


### PR DESCRIPTION
This is available on ArbOwnerPublic because it can be useful to inspect for non-ArbOwner accounts (especially, the accounts to which the mint burn authorization has been granted.)

Part of: NIT-3524