### PR TITLE
Add setMaxBlockGasLimit to ArbOwner and getMaxTxGasLimit to ArbGasInfo precompiles

### DIFF
--- a/ArbGasInfo.sol
+++ b/ArbGasInfo.sol
@@ -49,8 +49,12 @@ interface ArbGasInfo {
     function getPricesInArbGas() external view returns (uint256, uint256, uint256);
 
     /// @notice Get the gas accounting parameters. `gasPoolMax` is always zero, as the exponential pricing model has no such notion.
-    /// @return (speedLimitPerSecond, gasPoolMax, maxTxGasLimit)
+    /// @return (speedLimitPerSecond, gasPoolMax, maxBlockGasLimit)
     function getGasAccountingParams() external view returns (uint256, uint256, uint256);
+
+    /// @notice Get the maxTxGasLimit
+    /// @notice Available in ArbOS version 50 and above
+    function getMaxTxGasLimit() external view returns (uint256);
 
     /// @notice Get the minimum gas price needed for a tx to succeed
     function getMinimumGasPrice() external view returns (uint256);

--- a/ArbOwner.sol
+++ b/ArbOwner.sol
@@ -81,8 +81,14 @@ interface ArbOwner {
         uint64 limit
     ) external;
 
-    /// @notice Set the maximum size a tx (and block) can be
+    /// @notice Set the maximum size a tx can be
     function setMaxTxGasLimit(
+        uint64 limit
+    ) external;
+
+    /// @notice Set the maximum size a block can be
+    /// @notice Available in ArbOS version 50 and above
+    function setMaxBlockGasLimit(
         uint64 limit
     ) external;
 


### PR DESCRIPTION
Introduces EIP-7825 related methods to ArbOwner and ArbGasInfo precompiles.
* `setMaxBlockGasLimit` is a new method introduced to `ArbOwner` allowing it to independently set max block gas limit and max tx gas limit. Previously `setMaxTxGasLimit` was used to set both the limits
* `getMaxTxGasLimit` is added to `ArbGasInfo` precompile to fetch max tx gas limit

Part of NIT-3644