### PR TITLE
Allow collecting tips in arbos

### DIFF
--- a/ArbOwner.sol
+++ b/ArbOwner.sol
@@ -396,11 +396,11 @@ interface ArbOwner {
     ) external;
 
     /// @notice Set the minimum tip (wei per gas) for tip collection.
-    /// @notice Tips below this floor are dropped.
-    /// @notice Set to 0 to drop all tips (default). Set to 1 to collect all tips.
+    /// @notice Enables or disables tip collection.
+    /// @notice When enabled, transaction tips are collected by the network fee account.
     /// @notice Available in ArbOS version 60 and above
-    function setTipCapFloor(
-        uint256 tipCapFloor
+    function setCollectTips(
+        bool collectTips
     ) external;
 
     /// @notice Sets the max amount of stylus contract fragments that can be used to deploy a stylus contract

--- a/ArbOwner.sol
+++ b/ArbOwner.sol
@@ -395,9 +395,8 @@ interface ArbOwner {
         ArbMultiGasConstraintsTypes.ResourceConstraint[] calldata constraints
     ) external;
 
-    /// @notice Set the minimum tip (wei per gas) for tip collection.
     /// @notice Enables or disables tip collection.
-    /// @notice When enabled, transaction tips are collected by the network fee account.
+    /// @notice When enabled, transaction tips are sent to the network fee account.
     /// @notice Available in ArbOS version 60 and above
     function setCollectTips(
         bool collectTips

--- a/ArbOwner.sol
+++ b/ArbOwner.sol
@@ -395,6 +395,14 @@ interface ArbOwner {
         ArbMultiGasConstraintsTypes.ResourceConstraint[] calldata constraints
     ) external;
 
+    /// @notice Set the minimum tip (wei per gas) for tip collection.
+    /// @notice Tips below this floor are dropped.
+    /// @notice Set to 0 to drop all tips (default). Set to 1 to collect all tips.
+    /// @notice Available in ArbOS version 60 and above
+    function setTipCapFloor(
+        uint256 tipCapFloor
+    ) external;
+
     /// @notice Sets the max amount of stylus contract fragments that can be used to deploy a stylus contract
     /// @notice Available in ArbOS version 60 and above
     function setMaxStylusContractFragments(

--- a/ArbOwnerPublic.sol
+++ b/ArbOwnerPublic.sol
@@ -83,6 +83,11 @@ interface ArbOwnerPublic {
     /// @notice Available in ArbOS version 40 with default as false
     function isCalldataPriceIncreaseEnabled() external view returns (bool);
 
+    /// @notice Get the minimum tip (wei per gas) for tip collection.
+    /// @notice Returns 0 if not set, meaning all tips are dropped.
+    /// @notice Available in ArbOS version 60 and above
+    function getTipCapFloor() external view returns (uint256);
+
     /// @notice Get the max amount of stylus contract fragments that can be used to deploy a stylus contract
     /// @notice Available in ArbOS version 60 and above
     function getMaxStylusContractFragments() external view returns (uint8);

--- a/ArbOwnerPublic.sol
+++ b/ArbOwnerPublic.sol
@@ -83,10 +83,9 @@ interface ArbOwnerPublic {
     /// @notice Available in ArbOS version 40 with default as false
     function isCalldataPriceIncreaseEnabled() external view returns (bool);
 
-    /// @notice Get the minimum tip (wei per gas) for tip collection.
-    /// @notice Returns 0 if not set, meaning all tips are dropped.
+    /// @notice Returns whether tip collection is enabled.
     /// @notice Available in ArbOS version 60 and above
-    function getTipCapFloor() external view returns (uint256);
+    function getCollectTips() external view returns (bool);
 
     /// @notice Get the max amount of stylus contract fragments that can be used to deploy a stylus contract
     /// @notice Available in ArbOS version 60 and above


### PR DESCRIPTION
Adding
-  `ArbOwner` — `SetCollectTips(bool)` allows chain owner to enable/disable tip collection
- `ArbOwnerPublic` — `GetCollectTips()` bool allows anyone to query the setting

Both gated to ArbOS v60+


pulled in by https://github.com/OffchainLabs/nitro/pull/4515
related to NIT-4659