### PR TITLE
ArbOwner-configurable gas charge for Stylus activation

### DIFF
--- a/ArbOwner.sol
+++ b/ArbOwner.sol
@@ -409,7 +409,7 @@ interface ArbOwner {
     ) external;
 
     /// @notice Sets the constant gas charge applied before each stylus contract activation.
-    /// @notice Defaults to zero. Raise to deter DOS via activations, or set above the block gas limit to block all activations.
+    /// @notice Defaults to zero.
     /// @notice Available in ArbOS version 60 and above
     function setWasmActivationGas(
         uint64 gas

--- a/ArbOwner.sol
+++ b/ArbOwner.sol
@@ -401,6 +401,13 @@ interface ArbOwner {
         uint8 maxFragments
     ) external;
 
+    /// @notice Sets the constant gas charge applied before each stylus contract activation.
+    /// @notice Defaults to zero. Raise to deter DOS via activations, or set above the block gas limit to block all activations.
+    /// @notice Available in ArbOS version 60 and above
+    function setWasmActivationGas(
+        uint64 gas
+    ) external;
+
     /// Emitted when a successful call is made to this precompile
     event OwnerActs(bytes4 indexed method, address indexed owner, bytes data);
 }

--- a/ArbWasm.sol
+++ b/ArbWasm.sol
@@ -111,6 +111,11 @@ interface ArbWasm {
     /// @return count the number of same-block programs.
     function blockCacheSize() external view returns (uint16 count);
 
+    /// @notice Gets the constant gas charge applied before each stylus contract activation.
+    /// @notice Available in ArbOS version 60 and above
+    /// @return gas the activation gas charge
+    function activationGas() external view returns (uint64 gas);
+
     event ProgramActivated(
         bytes32 indexed codehash,
         bytes32 moduleHash,


### PR DESCRIPTION
Precompile setter and getter for the new activation gas charging.

Part of NIT-4706